### PR TITLE
Add BAMFFragenkatalogScraper application and tests

### DIFF
--- a/dotnet/language-learning-tools.sln
+++ b/dotnet/language-learning-tools.sln
@@ -1,0 +1,59 @@
+﻿Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{827E0CD3-B72D-47B6-A68D-7590B98EB39B}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "apps", "apps", "{AD2A5A3B-A595-3E96-334A-002D08FE630C}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "cli", "cli", "{F1846B6D-4AF6-9FBC-6FFF-07E3EFC3E8DE}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BAMFFragenkatalogScraper", "src\apps\cli\BAMFFragenkatalogScraper\BAMFFragenkatalogScraper.csproj", "{165D07D8-54F1-4591-A0BF-0D5A4BBB1EDC}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BAMFFragenkatalogScraper.Tests", "src\apps\cli\BAMFFragenkatalogScraper.Tests\BAMFFragenkatalogScraper.Tests.csproj", "{A010FB8F-B764-4EF6-87C4-A9CD497ADFCF}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{165D07D8-54F1-4591-A0BF-0D5A4BBB1EDC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{165D07D8-54F1-4591-A0BF-0D5A4BBB1EDC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{165D07D8-54F1-4591-A0BF-0D5A4BBB1EDC}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{165D07D8-54F1-4591-A0BF-0D5A4BBB1EDC}.Debug|x64.Build.0 = Debug|Any CPU
+		{165D07D8-54F1-4591-A0BF-0D5A4BBB1EDC}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{165D07D8-54F1-4591-A0BF-0D5A4BBB1EDC}.Debug|x86.Build.0 = Debug|Any CPU
+		{165D07D8-54F1-4591-A0BF-0D5A4BBB1EDC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{165D07D8-54F1-4591-A0BF-0D5A4BBB1EDC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{165D07D8-54F1-4591-A0BF-0D5A4BBB1EDC}.Release|x64.ActiveCfg = Release|Any CPU
+		{165D07D8-54F1-4591-A0BF-0D5A4BBB1EDC}.Release|x64.Build.0 = Release|Any CPU
+		{165D07D8-54F1-4591-A0BF-0D5A4BBB1EDC}.Release|x86.ActiveCfg = Release|Any CPU
+		{165D07D8-54F1-4591-A0BF-0D5A4BBB1EDC}.Release|x86.Build.0 = Release|Any CPU
+		{A010FB8F-B764-4EF6-87C4-A9CD497ADFCF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A010FB8F-B764-4EF6-87C4-A9CD497ADFCF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A010FB8F-B764-4EF6-87C4-A9CD497ADFCF}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{A010FB8F-B764-4EF6-87C4-A9CD497ADFCF}.Debug|x64.Build.0 = Debug|Any CPU
+		{A010FB8F-B764-4EF6-87C4-A9CD497ADFCF}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A010FB8F-B764-4EF6-87C4-A9CD497ADFCF}.Debug|x86.Build.0 = Debug|Any CPU
+		{A010FB8F-B764-4EF6-87C4-A9CD497ADFCF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A010FB8F-B764-4EF6-87C4-A9CD497ADFCF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A010FB8F-B764-4EF6-87C4-A9CD497ADFCF}.Release|x64.ActiveCfg = Release|Any CPU
+		{A010FB8F-B764-4EF6-87C4-A9CD497ADFCF}.Release|x64.Build.0 = Release|Any CPU
+		{A010FB8F-B764-4EF6-87C4-A9CD497ADFCF}.Release|x86.ActiveCfg = Release|Any CPU
+		{A010FB8F-B764-4EF6-87C4-A9CD497ADFCF}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{AD2A5A3B-A595-3E96-334A-002D08FE630C} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{F1846B6D-4AF6-9FBC-6FFF-07E3EFC3E8DE} = {AD2A5A3B-A595-3E96-334A-002D08FE630C}
+		{165D07D8-54F1-4591-A0BF-0D5A4BBB1EDC} = {F1846B6D-4AF6-9FBC-6FFF-07E3EFC3E8DE}
+		{A010FB8F-B764-4EF6-87C4-A9CD497ADFCF} = {F1846B6D-4AF6-9FBC-6FFF-07E3EFC3E8DE}
+	EndGlobalSection
+EndGlobal

--- a/dotnet/src/apps/cli/BAMFFragenkatalogScraper.Tests/BAMFFragenkatalogScraper.Tests.csproj
+++ b/dotnet/src/apps/cli/BAMFFragenkatalogScraper.Tests/BAMFFragenkatalogScraper.Tests.csproj
@@ -1,0 +1,31 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <AssemblyName>BAMFFragenkatalogScraper.Tests</AssemblyName>
+    <RootNamespace>BAMFFragenkatalogScraper.Tests</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="ReportGenerator" Version="5.4.4" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../BAMFFragenkatalogScraper/BAMFFragenkatalogScraper.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/dotnet/src/apps/cli/BAMFFragenkatalogScraper.Tests/ProgramTests.cs
+++ b/dotnet/src/apps/cli/BAMFFragenkatalogScraper.Tests/ProgramTests.cs
@@ -1,0 +1,76 @@
+﻿namespace LanguageLearningTools.BAMFFragenkatalogScraper.Tests;
+
+using Microsoft.Playwright;
+using static Microsoft.Playwright.Assertions;
+
+public class ProgramTests
+{
+    private readonly BAMFScraperConfiguration _defaultConfig;
+
+    public ProgramTests()
+    {
+        _defaultConfig = new BAMFScraperConfiguration();
+    }
+
+    [Fact]
+    public void DefaultConfig_ShouldHaveCorrectValues()
+    {
+        Assert.Equal("https://oet.bamf.de/ords/oetut/f?p=514:1::::::", _defaultConfig.TestUrl);
+        Assert.Equal("Berlin", _defaultConfig.BundesLand);
+        Assert.Equal("screenshots", _defaultConfig.ScreenshotDirectory);
+        Assert.Equal("#P1_BUL_ID", _defaultConfig.StateDropdownSelector);
+        Assert.Equal("#R57608719341524241", _defaultConfig.QuestionElementSelector);
+        Assert.Equal("nächste Aufgabe >", _defaultConfig.NextQuestionButtonText);
+        Assert.Equal("Zum Fragenkatalog", _defaultConfig.StartButtonText);
+        Assert.Equal(310, _defaultConfig.TotalQuestions);
+    }
+
+    [Fact]
+    public async Task UIElements_ShouldExistAndBeInteractable()
+    {
+        // Setup Playwright
+        using var playwright = await Playwright.CreateAsync();
+        var browser = await playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions 
+        { 
+            Headless = false
+        });
+        var page = await browser.NewPageAsync();
+
+        try
+        {
+            // Navigate to the test page
+            await page.GotoAsync(_defaultConfig.TestUrl);
+
+            // Check if state dropdown exists and is visible
+            var stateDropdown = page.Locator(_defaultConfig.StateDropdownSelector);
+            await Expect(stateDropdown).ToBeVisibleAsync();
+
+            // Verify Berlin is available in the dropdown
+            var options = await page.Locator($"{_defaultConfig.StateDropdownSelector} option").AllTextContentsAsync();
+            Assert.Contains(_defaultConfig.BundesLand, options);
+
+            // Select Berlin and verify it's selected
+            await page.SelectOptionAsync(_defaultConfig.StateDropdownSelector, _defaultConfig.BundesLand);
+            await Expect(page.Locator($"{_defaultConfig.StateDropdownSelector} option:checked")).ToHaveTextAsync(_defaultConfig.BundesLand);
+
+            // Verify start button exists and is clickable
+            var startButton = page.GetByText(_defaultConfig.StartButtonText);
+            await Expect(startButton).ToBeVisibleAsync();
+            await Expect(startButton).ToBeEnabledAsync();
+            await startButton.ClickAsync();
+
+            // After clicking start, verify question element exists
+            var questionElement = page.Locator(_defaultConfig.QuestionElementSelector);
+            await Expect(questionElement).ToBeVisibleAsync();
+
+            // Verify next question button exists
+            var nextButton = page.GetByText(_defaultConfig.NextQuestionButtonText);
+            await Expect(nextButton).ToBeVisibleAsync();
+            await Expect(nextButton).ToBeEnabledAsync();
+        }
+        finally
+        {
+            await browser.CloseAsync();
+        }
+    }
+}

--- a/dotnet/src/apps/cli/BAMFFragenkatalogScraper/BAMFFragenkatalogScraper.csproj
+++ b/dotnet/src/apps/cli/BAMFFragenkatalogScraper/BAMFFragenkatalogScraper.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AssemblyName>BAMFFragenkatalogScraper</AssemblyName>
+    <RootNamespace>BAMFFragenkatalogScraper</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Playwright" Version="1.50.0" />
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
+  </ItemGroup>
+
+</Project>

--- a/dotnet/src/apps/cli/BAMFFragenkatalogScraper/Program.cs
+++ b/dotnet/src/apps/cli/BAMFFragenkatalogScraper/Program.cs
@@ -1,0 +1,123 @@
+﻿[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("BAMFFragenkatalogScraper.Tests")]
+
+namespace LanguageLearningTools.BAMFFragenkatalogScraper;
+
+using Microsoft.Playwright;
+using System.CommandLine;
+using static Microsoft.Playwright.Assertions;
+
+internal class BAMFScraperConfiguration
+{
+    public string TestUrl { get; set; } = "https://oet.bamf.de/ords/oetut/f?p=514:1::::::";
+    public string BundesLand { get; set; } = "Berlin";
+    public int QuestionDelayMs { get; set; } = 5000;
+    public string ScreenshotDirectory { get; set; } = "screenshots";
+    public string StateDropdownSelector { get; set; } = "#P1_BUL_ID";
+    public string QuestionElementSelector { get; set; } = "#R57608719341524241";
+    public string NextQuestionButtonText { get; set; } = "nächste Aufgabe >";
+    public string StartButtonText { get; set; } = "Zum Fragenkatalog";
+    public int TotalQuestions { get; set; } = 310;
+}
+
+public class Program
+{
+    public static async Task<int> Main(string[] args)
+    {
+        var urlOption = new Option<string>(
+            name: "--url",
+            description: "Test URL",
+            getDefaultValue: () => "https://oet.bamf.de/ords/oetut/f?p=514:1::::::"
+        );
+
+        var bundeslandOption = new Option<string>(
+            name: "--bundesland",
+            description: "Federal state",
+            getDefaultValue: () => "Berlin"
+        );
+
+        var outputOption = new Option<string>(
+            name: "--output",
+            description: "Screenshot output directory",
+            getDefaultValue: () => "screenshots"
+        );
+
+        var rootCommand = new RootCommand("BAMF Interaktiver Fragenkatalog Scraper");
+        rootCommand.AddOption(urlOption);
+        rootCommand.AddOption(bundeslandOption);
+        rootCommand.AddOption(outputOption);
+
+        rootCommand.SetHandler(async (url, bundesland, output) =>
+        {
+            var config = new BAMFScraperConfiguration
+            {
+                TestUrl = url,
+                BundesLand = bundesland,
+                ScreenshotDirectory = output
+            };
+
+            Console.WriteLine($"Starting to scrape with following configuration:");
+            Console.WriteLine($"URL: {config.TestUrl}");
+            Console.WriteLine($"Bundesland: {config.BundesLand}");
+            Console.WriteLine($"Output directory: {config.ScreenshotDirectory}");
+            Console.WriteLine();
+
+            SetDefaultExpectTimeout(5_000);
+            using var playwright = await Playwright.CreateAsync();
+            var options = new BrowserTypeLaunchOptions
+            {
+                Headless = false,
+                SlowMo = 50
+            };
+
+            // Ensure screenshot directory exists
+            Directory.CreateDirectory(config.ScreenshotDirectory);
+
+            await using var browser = await playwright.Chromium.LaunchAsync(options);
+            var page = await browser.NewPageAsync();
+            await page.GotoAsync(config.TestUrl);
+
+            // Select state from the dropdown
+            await page.SelectOptionAsync(config.StateDropdownSelector, config.BundesLand);
+
+            // Assert that state is selected using Playwright assertions
+            await Expect(page.Locator($"{config.StateDropdownSelector} option:checked")).ToHaveTextAsync(config.BundesLand);
+
+            // Click start button
+            await page.GetByText(config.StartButtonText).ClickAsync();
+
+            bool isLastQuestion = false;
+            while (!isLastQuestion)
+            {
+                // Get the current question number
+                var headerText = await page.Locator("td.RegionHeader").Filter(new() { HasText = "Aufgabe" }).TextContentAsync();
+                
+                // Get the question number from the header text
+                var questionNumber = headerText?.Split(' ')[1].PadLeft(3, '0');
+
+                // Screenshot just the question element
+                var questionElement = page.Locator(config.QuestionElementSelector);
+                await questionElement.ScreenshotAsync(new()
+                {
+                    Path = Path.Combine(config.ScreenshotDirectory, $"question_{questionNumber}.png")
+                });
+
+                // Check if we've reached the last question
+                isLastQuestion = headerText == $"Aufgabe {config.TotalQuestions} von {config.TotalQuestions}";
+
+                if (!isLastQuestion)
+                {
+                    // Move to next question
+                    await page.GetByText(config.NextQuestionButtonText).ClickAsync();
+                    // Add a delay between questions to be polite
+                    await Task.Delay(config.QuestionDelayMs);
+                    // Wait for network to be idle
+                    await page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+                }
+            }
+
+            Console.WriteLine("Scrape completed - all questions processed");
+        }, urlOption, bundeslandOption, outputOption);
+
+        return await rootCommand.InvokeAsync(args);
+    }
+}

--- a/dotnet/src/apps/cli/BAMFFragenkatalogScraper/README.md
+++ b/dotnet/src/apps/cli/BAMFFragenkatalogScraper/README.md
@@ -1,0 +1,36 @@
+# BAMF Interaktiver Fragenkatalog Scraper
+
+This console application automates the process of capturing screenshots from the official BAMF (Bundesamt für Migration und Flüchtlinge) [interactive question catalog](https://www.bamf.de/DE/Themen/Integration/ZugewanderteTeilnehmende/OnlineTestcenter/online-testcenter-node.html), which includes both the Leben in Deutschland Test and Einbürgerungstest questions. It's designed to help people preparing for their German citizenship test by collecting all test questions for study purposes.
+
+## Features
+
+- Automatically navigates through all 310 test questions
+- Takes screenshots of each question
+- Configurable for different German federal states (Bundesländer)
+- Customizable screenshot output directory
+- Polite scraping with built-in delays to respect server resources
+
+## Requirements
+
+- .NET 9.0 or later
+- Internet connection
+- Microsoft Playwright dependencies (will be installed automatically)
+
+## Usage
+
+```bash
+BAMFFragenkatalogScraper [options]
+
+Options:
+  --url <url>          Test URL (default: https://oet.bamf.de/ords/oetut/f?p=514:1::::::)
+  --bundesland <state> Federal state (default: Berlin)
+  --output <dir>       Screenshot output directory (default: screenshots)
+  --help              Show this help message
+
+Example:
+  BAMFFragenkatalogScraper --bundesland "Hamburg" --output "my-screenshots"
+```
+
+## Legal Notice
+
+This tool is for personal educational use only. Please respect the terms of service of the BAMF website and use the tool responsibly.


### PR DESCRIPTION
Introduce a new console application that automates the process of capturing screenshots from the BAMF interactive question catalog, along with a test suite to ensure functionality.