### PR TITLE
Fix link to Subtitle JSON Viewer in README

### DIFF
--- a/dotnet/src/apps/cli/SubtitleTranslator/README.md
+++ b/dotnet/src/apps/cli/SubtitleTranslator/README.md
@@ -171,7 +171,7 @@ We made a simple web viewer to display the data in a table format:
 - Has basic search/filter for finding specific lines
 - Works on mobile browsers too
 
-**→ [Subtitle JSON Viewer](../../../docs/tools/subtitle-json-viewer.html)**
+**→ [Subtitle JSON Viewer](../../../../../docs/tools/subtitle-json-viewer.html)**
 
 Open that HTML file in your browser and upload your JSON file.
 


### PR DESCRIPTION
Update the path to the Subtitle JSON Viewer in the README to ensure it directs users correctly.